### PR TITLE
feat(welcome):ログインページのみヘッダーを非表示にしました#38

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { HeaderService } from './header/header.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'wordbook';
+  constructor(private header: HeaderService) {}
+  ngOnInit() {
+    this.header.show();
+  }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,26 +1,32 @@
-<mat-toolbar class="header" color="primary">
+<mat-toolbar *ngIf="header.visible" class="header" color="primary">
   <mat-toolbar-row>
     <span routerLink="/">LOGO</span>
     <span class="header__spacer"></span>
-    <mat-icon class="header__icon" aria-hidden="true" aria-label="search">search</mat-icon>
-    <button mat-icon-button routerLink="/addvocabulary"><mat-icon class="header__icon" aria-hidden="true" aria-label="add">add_circle_outline</mat-icon></button>
-  <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="menu">
-    <mat-icon aria-hidden="true" aria-label="menu">more_vert</mat-icon>
-  </button>
-  <mat-menu #menu="matMenu">
-    <button mat-menu-item>
-      <mat-icon>account_circle</mat-icon>
-      <span routerLink="/mypage">マイページ</span>
+    <mat-icon class="header__icon" aria-hidden="true" aria-label="search"
+      >search</mat-icon
+    >
+    <button mat-icon-button routerLink="/addvocabulary">
+      <mat-icon class="header__icon" aria-hidden="true" aria-label="add"
+        >add_circle_outline</mat-icon
+      >
     </button>
-    <button mat-menu-item>
-      <mat-icon>settings</mat-icon>
-      <span routerLink="/setting">設定</span>
+    <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="menu">
+      <mat-icon aria-hidden="true" aria-label="menu">more_vert</mat-icon>
     </button>
-    <!-- asynで最新の値があるか判断 -->
-    <button *ngIf="user$ | async" (click)="logout()" mat-menu-item>
-      <mat-icon>exit_to_app</mat-icon>
-      <span>ログアウト</span>
-    </button>
-  </mat-menu>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item>
+        <mat-icon>account_circle</mat-icon>
+        <span routerLink="/mypage">マイページ</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>settings</mat-icon>
+        <span routerLink="/setting">設定</span>
+      </button>
+      <!-- asynで最新の値があるか判断 -->
+      <button *ngIf="user$ | async" (click)="logout()" mat-menu-item>
+        <mat-icon>exit_to_app</mat-icon>
+        <span>ログアウト</span>
+      </button>
+    </mat-menu>
   </mat-toolbar-row>
 </mat-toolbar>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
+import { HeaderService } from './header.service';
 
 @Component({
   selector: 'app-header',
@@ -9,12 +10,9 @@ import { AuthService } from '../services/auth.service';
 export class HeaderComponent implements OnInit {
   // user$は最新のuserが入る箱
   user$ = this.authService.afUser$;
-  constructor(
-    private authService: AuthService,
-  ) { }
+  constructor(private authService: AuthService, public header: HeaderService) {}
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   logout() {
     // authServieの中のログアウト関数を呼ぶ

--- a/src/app/header/header.service.ts
+++ b/src/app/header/header.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HeaderService {
+  visible: boolean;
+  constructor() {
+    this.visible = false;
+  }
+  hide() {
+    this.visible = false;
+  }
+  show() {
+    this.visible = true;
+  }
+}

--- a/src/app/welcome/welcome/welcome.component.ts
+++ b/src/app/welcome/welcome/welcome.component.ts
@@ -1,18 +1,25 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { AuthService } from 'src/app/services/auth.service';
+import { HeaderService } from 'src/app/header/header.service';
 
 @Component({
   selector: 'app-welcome',
   templateUrl: './welcome.component.html',
   styleUrls: ['./welcome.component.scss']
 })
-export class WelcomeComponent implements OnInit {
+export class WelcomeComponent implements OnInit, OnDestroy {
   constructor(
     // 外部サービスを自分のコンポーネントで使えるようにする
-    private authService: AuthService
+    private authService: AuthService,
+    private header: HeaderService
   ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.header.hide();
+  }
+  ngOnDestroy() {
+    this.header.show();
+  }
 
   login() {
     // authServieの中のログイン関数を呼ぶ


### PR DESCRIPTION
ログインページのみヘッダーを非表示にしました。
ご確認お願いいたします。

ログインページ
![image](https://user-images.githubusercontent.com/59854793/73327276-99bd3e80-4298-11ea-8852-a95166b7ce1b.png)

それ以外のページ
<img width="296" alt="スクリーンショット 2020-01-29 13 10 18" src="https://user-images.githubusercontent.com/59854793/73327319-ce30fa80-4298-11ea-9077-16b37df31b3c.png">

