### PR TITLE
feat(card):フラッシュカード実装しました #18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5144,6 +5144,14 @@
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
     },
+    "dom7": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-2.1.3.tgz",
+      "integrity": "sha512-QTxHHDox+M6ZFz1zHPAHZKI3JOHY5iY4i9BK2uctlggxKQwRhO3q3HHFq1BKsT25Bm/ySSj70K6Wk/G4bs9rMQ==",
+      "requires": {
+        "ssr-window": "^1.0.1"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -10619,6 +10627,14 @@
         "opencollective-postinstall": "^2.0.2"
       }
     },
+    "ngx-swiper-wrapper": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/ngx-swiper-wrapper/-/ngx-swiper-wrapper-8.0.2.tgz",
+      "integrity": "sha512-rL1h1x1bYpRx1nTyJquCVdgwhQXqProIHb8hfC2oElJEYBO/fOqCbdmNG5NfkFOtKCrIVVfH9n0rc7whLQCmhQ==",
+      "requires": {
+        "swiper": "^4.5.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -13543,6 +13559,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssr-window": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-1.0.1.tgz",
+      "integrity": "sha512-dgFqB+f00LJTEgb6UXhx0h+SrG50LJvti2yMKMqAgzfUmUXZrLSv2fjULF7AWGwK25EXu8+smLR3jYsJQChPsg=="
+    },
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -13934,6 +13955,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         }
+      }
+    },
+    "swiper": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-4.5.1.tgz",
+      "integrity": "sha512-se6I7PWWu950NAMXXT+ENtF/6SVb8mPyO+bTfNxbQBILSeLqsYp3Ndap+YOA0EczOIUlea274PKejT6gKZDseA==",
+      "requires": {
+        "dom7": "^2.1.3",
+        "ssr-window": "^1.0.1"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "firebase-tools": "^7.15.1",
     "hammerjs": "^2.0.8",
     "ngx-infinite-scroll": "^8.0.1",
+    "ngx-swiper-wrapper": "^8.0.2",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1"

--- a/src/app/shared/word/word.component.ts
+++ b/src/app/shared/word/word.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Word } from 'src/app/interfaces/word';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Vocabulary } from 'src/app/interfaces/vocabulary';
 import { ActivatedRoute } from '@angular/router';
 import { VocabularyService } from 'src/app/services/vocabulary.service';

--- a/src/app/welcome/welcome/welcome.component.scss
+++ b/src/app/welcome/welcome/welcome.component.scss
@@ -1,22 +1,6 @@
-$pc: 1024px;
-$tab: 768px;
-$sp: 480px;
-@mixin pc {
-  @media (min-width: ($pc)) {
-    @content;
-  }
-}
-@mixin tab {
-  @media (max-width: ($tab)) {
-    @content;
-  }
-}
+@import 'mixins';
+@import 'variables';
 
-@mixin sp {
-  @media (max-width: ($sp)) {
-    @content;
-  }
-}
 .container {
   padding: 24px;
   display: flex;

--- a/src/app/wordlist/card/card.component.html
+++ b/src/app/wordlist/card/card.component.html
@@ -1,0 +1,8 @@
+<div class="tp-wrapper">
+  <div class="tp-box" (click)="toggleFlip()" [@flipState]="flip">
+    <div class="tp-box__side tp-box__front">
+      {{ word.surface }}
+    </div>
+    <div class="tp-box__side tp-box__back">{{ word.backside }}</div>
+  </div>
+</div>

--- a/src/app/wordlist/card/card.component.scss
+++ b/src/app/wordlist/card/card.component.scss
@@ -1,0 +1,50 @@
+@import 'mixins';
+@import 'variables';
+
+.tp-wrapper {
+  perspective: 2000px;
+}
+
+.tp-box {
+  position: relative;
+  @include pc {
+    max-width: 40%;
+  }
+  @include sp {
+    width: 80%;
+  }
+  height: 300px;
+  margin: 3rem auto;
+  transform-style: preserve-3d;
+  transform: transform 1s;
+}
+.tp-box__side {
+  width: 100%;
+  height: auto;
+  position: absolute;
+  backface-visibility: hidden;
+  color: #fff;
+  text-align: center;
+  line-height: 25px;
+  font-size: 24px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 4px;
+  border: solid 1px #dcdcdc;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 32px;
+}
+.tp-box__front {
+  @include primary-color {
+    color: $primary-color;
+  }
+  background: white;
+  transform: rotateY(0deg);
+}
+.tp-box__back {
+  @include primary-color {
+    background: $primary-color;
+  }
+  transform: rotateY(-180deg);
+}

--- a/src/app/wordlist/card/card.component.spec.ts
+++ b/src/app/wordlist/card/card.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CardComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/wordlist/card/card.component.ts
+++ b/src/app/wordlist/card/card.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Word } from 'src/app/interfaces/word';
+import {
+  trigger,
+  state,
+  style,
+  animate,
+  transition
+} from '@angular/animations';
+
+@Component({
+  selector: 'app-card',
+  templateUrl: './card.component.html',
+  styleUrls: ['./card.component.scss'],
+  animations: [
+    trigger('flipState', [
+      state(
+        'active',
+        style({
+          transform: 'rotateY(180deg)'
+        })
+      ),
+      state(
+        'inactive',
+        style({
+          transform: 'rotateY(0)'
+        })
+      ),
+
+      transition('active => inactive', animate('400ms ease-out')),
+      transition('inactive => active', animate('400ms ease-in'))
+    ])
+  ]
+})
+export class CardComponent implements OnInit {
+  @Input() word: Word;
+  flip = 'inactive';
+  constructor() {}
+
+  ngOnInit() {}
+
+  toggleFlip() {
+    this.flip = this.flip === 'inactive' ? 'active' : 'inactive';
+  }
+}

--- a/src/app/wordlist/wordlist.module.ts
+++ b/src/app/wordlist/wordlist.module.ts
@@ -4,14 +4,18 @@ import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { WordlistRoutingModule } from './wordlist-routing.module';
 import { WordlistComponent } from './wordlist/wordlist.component';
 import { SharedModule } from '../shared/shared.module';
-
+import { SwiperModule } from 'ngx-swiper-wrapper';
+import { CardComponent } from './card/card.component';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 @NgModule({
-  declarations: [WordlistComponent],
+  declarations: [WordlistComponent, CardComponent],
   imports: [
     CommonModule,
     WordlistRoutingModule,
     SharedModule,
-    InfiniteScrollModule
+    InfiniteScrollModule,
+    SwiperModule,
+    MatProgressBarModule
   ]
 })
 export class WordlistModule {}

--- a/src/app/wordlist/wordlist/wordlist.component.html
+++ b/src/app/wordlist/wordlist/wordlist.component.html
@@ -1,30 +1,68 @@
 <div class="container" *ngIf="vocabulary$ | async as vocabulary">
-  <h2>単語一覧</h2>
-  <app-word
-    *ngFor="let word of words"
-    [word]="word"
-    (delete)="deleteWord($event)"
-  ></app-word>
-  <button
-    *ngIf="vocabulary.authorId === userId"
-    mat-mini-fab
-    color="primary"
-    routerLink="/wordlist/{{ vocabulary.vocabularyId }}/addword"
-    class="add"
-  >
-    <i class="material-icons">
-      add
-    </i>
-  </button>
-  <button mat-mini-fab color="primary" class="flash">
-    <i class="material-icons">
-      style
-    </i>
-  </button>
-  <div
-    infiniteScroll
-    [infiniteScrollDistance]="2"
-    [infiniteScrollThrottle]="50"
-    (scrolled)="getWords()"
-  ></div>
+  <ng-container *ngIf="flipped; else isflip">
+    <h2>単語一覧</h2>
+    <app-word
+      *ngFor="let word of words"
+      [word]="word"
+      (delete)="deleteWord($event)"
+    ></app-word>
+    <button
+      *ngIf="vocabulary.authorId === userId"
+      mat-mini-fab
+      color="primary"
+      routerLink="/wordlist/{{ vocabulary.vocabularyId }}/addword"
+      class="add"
+    >
+      <mat-icon class="material-icons">
+        add
+      </mat-icon>
+    </button>
+    <button
+      mat-mini-fab
+      color="primary"
+      class="flash"
+      (click)="flip()"
+      *ngIf="!(words.length === 0)"
+    >
+      <mat-icon class="material-icons">
+        style
+      </mat-icon>
+    </button>
+    <div
+      infiniteScroll
+      [infiniteScrollDistance]="2"
+      [infiniteScrollThrottle]="50"
+      (scrolled)="getWords()"
+    ></div>
+  </ng-container>
 </div>
+
+<ng-template #isflip>
+  <div class="flip">
+    <div class="inner">
+      <mat-progress-bar
+        mode="determinate"
+        [value]="progress"
+      ></mat-progress-bar>
+      <ng-template #zero>
+        <p>
+          0 %
+        </p></ng-template
+      >
+    </div>
+    <p *ngIf="!(progress === undefined); else zero">{{ progress + ' %' }}</p>
+    <swiper
+      [config]="config"
+      [(index)]="index"
+      (indexChange)="onIndexChange($event)"
+    >
+      <app-card *ngFor="let word of words" [word]="word"></app-card>
+    </swiper>
+
+    <button mat-mini-fab color="primary" class="flash" (click)="list()">
+      <mat-icon class="material-icons">
+        list
+      </mat-icon>
+    </button>
+  </div>
+</ng-template>

--- a/src/app/wordlist/wordlist/wordlist.component.scss
+++ b/src/app/wordlist/wordlist/wordlist.component.scss
@@ -1,3 +1,6 @@
+@import 'mixins';
+@import 'variables';
+
 button {
   display: block;
   margin-bottom: 16px;
@@ -8,5 +11,11 @@ button {
   }
   &.flash {
     bottom: 80px;
+    z-index: 1000;
   }
+}
+.inner {
+  width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
 }

--- a/src/app/wordlist/wordlist/wordlist.component.ts
+++ b/src/app/wordlist/wordlist/wordlist.component.ts
@@ -7,6 +7,7 @@ import { switchMap, take } from 'rxjs/operators';
 import { AuthService } from 'src/app/services/auth.service';
 import { Word } from 'src/app/interfaces/word';
 import { WordService } from 'src/app/services/word.service';
+import { SwiperConfigInterface } from 'ngx-swiper-wrapper';
 
 @Component({
   selector: 'app-wordlist',
@@ -17,9 +18,18 @@ export class WordlistComponent implements OnInit {
   vocabulary$: Observable<Vocabulary>;
   userId: string = this.authService.uid;
   lastDoc;
-  words: Word[] = [];
   isComplete: boolean;
   vocabularyId: string;
+  config: SwiperConfigInterface = {
+    loop: false,
+    navigation: false,
+    centeredSlides: true,
+    slidesPerView: 1
+  };
+  index: number;
+  flipped: boolean;
+  words: Word[] = [];
+  progress: number;
   constructor(
     private route: ActivatedRoute,
     private vocabularyService: VocabularyService,
@@ -36,6 +46,7 @@ export class WordlistComponent implements OnInit {
     );
     this.vocabularyId = this.route.snapshot.paramMap.get('vocabularyId');
     this.getWords();
+    this.flipped = true;
   }
   getWords() {
     if (this.isComplete) {
@@ -60,5 +71,17 @@ export class WordlistComponent implements OnInit {
   deleteWord(wordId: string) {
     const targetIndex = this.words.findIndex(word => word.wordId === wordId);
     this.words.splice(targetIndex, 1);
+  }
+  flip() {
+    this.flipped = false;
+  }
+  list() {
+    this.flipped = true;
+  }
+  onIndexChange(index: number) {
+    const result = (this.index / (this.words.length - 1)) * 100;
+    const n = 0;
+    this.progress = Math.floor(result * Math.pow(10, n)) / Math.pow(10, n);
+    return index;
   }
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,3 +1,19 @@
 @mixin primary-color {
   @content;
 }
+@mixin pc {
+  @media (min-width: ($pc)) {
+    @content;
+  }
+}
+@mixin tab {
+  @media (max-width: ($tab)) {
+    @content;
+  }
+}
+
+@mixin sp {
+  @media (max-width: ($sp)) {
+    @content;
+  }
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,1 +1,4 @@
 $primary-color: #fe602b;
+$pc: 1024px;
+$tab: 768px;
+$sp: 480px;


### PR DESCRIPTION
## 実装内容
- cardcomponentを追加し、クリックすると裏面表示、スワイプすると次のカードを表示させるようにしました
- progressbarがどこまで進んだか連動するようにしました

ご確認お願いいたします。

## 挙動
[![Image from Gyazo](https://i.gyazo.com/acdd4b91f4295ee3b1f0c153efc5668f.gif)](https://gyazo.com/acdd4b91f4295ee3b1f0c153efc5668f)