### PR TITLE
feat(addword):文字数制限追加 # 77

### DIFF
--- a/src/app/addword/addword/addword.component.html
+++ b/src/app/addword/addword/addword.component.html
@@ -20,6 +20,9 @@
       <mat-error *ngIf="surfaceControl.hasError('required')"
         >必須入力です</mat-error
       >
+      <mat-error *ngIf="surfaceControl.hasError('maxlength')"
+        >長過ぎます</mat-error
+      >
     </mat-form-field>
     <mat-form-field>
       <mat-label>裏面</mat-label>
@@ -32,6 +35,9 @@
       />
       <mat-error *ngIf="backsideControl.hasError('required')"
         >必須入力です</mat-error
+      >
+      <mat-error *ngIf="backsideControl.hasError('maxlength')"
+        >長過ぎます</mat-error
       >
     </mat-form-field>
     <button

--- a/src/app/addword/addword/addword.component.ts
+++ b/src/app/addword/addword/addword.component.ts
@@ -5,7 +5,7 @@ import { WordService } from 'src/app/services/word.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { switchMap, take } from 'rxjs/operators';
 
 @Component({
@@ -16,8 +16,8 @@ import { switchMap, take } from 'rxjs/operators';
 export class AddwordComponent implements OnInit {
   vocabularyId: string;
   form = this.fb.group({
-    surface: ['', [Validators.required]],
-    backside: ['', [Validators.required]]
+    surface: ['', [Validators.required, Validators.maxLength(300)]],
+    backside: ['', [Validators.required, Validators.maxLength(200)]]
   });
   isEditing: boolean;
   word$: Observable<Word>;


### PR DESCRIPTION
## 実装内容
- 単語登録時の文字数制限がなかったので追加しました

## 挙動
![image](https://user-images.githubusercontent.com/59854793/78204466-8adf4c00-74d4-11ea-9c1c-59ffc9426d6f.png)
